### PR TITLE
feat(service): add extraPorts for multi-port Services (v1.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ---
 
+## [1.6.0] — 2026-05-21
+
+### Added
+
+#### Multi-port Services (issue #52)
+
+- **`service.extraPorts`**: list of additional ports rendered on the same Service after the primary port. Unblocks workloads needing multiple ports on the same Pod selector (Odoo HTTP+gevent, Redis client+TLS, gRPC sidecars, exporters).
+- Schema enforces required `[name, port, targetPort]` per item with `additionalProperties: false`. Optional: `protocol` (TCP/UDP/SCTP, default TCP), `appProtocol`, `nodePort` (30000-32767).
+
+```yaml
+deployments:
+  odoo:
+    service:
+      port: 8069
+      targetPort: 8069
+      portName: odoo
+      extraPorts:
+        - name: gevent
+          port: 8072
+          targetPort: 8072
+          appProtocol: http
+        - name: metrics
+          port: 9090
+          targetPort: metrics
+```
+
+### Compatibility
+
+- Backward compatible: Services without `extraPorts` render byte-for-byte identical manifests.
+
+---
+
 ## [1.5.0] — 2026-05-08
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ TEST_CASES := \
 	tests/rbac.yaml:rbac:rbac \
 	tests/multi-deployment.yaml:multi:multi-deployment \
 	tests/service-disabled.yaml:svc-disabled:service-disabled \
+	tests/service-extra-ports.yaml:svc-extra-ports:service-extra-ports \
 	tests/raw-deployment.yaml:raw:raw-deployment \
 	tests/deployment-hooks-cronjobs.yaml:deploy-hooks:deploy-hooks-cj \
 	tests/hooks-sa-inheritance.yaml:hooks-sa:hooks-sa-inheritance \

--- a/charts/global-chart/Chart.yaml
+++ b/charts/global-chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.0
+version: 1.6.0
 
 # Application version deployed by this chart
-appVersion: "1.5.0"
+appVersion: "1.6.0"
 
 # Chart icon
 icon: https://helm.sh/img/helm.svg

--- a/charts/global-chart/README.md
+++ b/charts/global-chart/README.md
@@ -1,6 +1,6 @@
 # global-chart
 
-![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-1.5.0-informational?style=flat-square)
+![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
 
 Reusable Helm chart providing common building blocks—Deployments, Services, Ingress, Jobs, and more—for broadly adaptable Kubernetes applications.
 

--- a/charts/global-chart/templates/service.yaml
+++ b/charts/global-chart/templates/service.yaml
@@ -31,6 +31,18 @@ spec:
       targetPort: {{ ternary $svc.targetPort "http" (hasKey $svc "targetPort") }}
       protocol: {{ (ternary $svc.protocol "TCP" (hasKey $svc "protocol")) | upper }}
       name: {{ ternary $svc.portName "http" (hasKey $svc "portName") }}
+    {{- range (default (list) $svc.extraPorts) }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      targetPort: {{ .targetPort }}
+      protocol: {{ (default "TCP" .protocol) | upper }}
+      {{- with .appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
+      {{- with .nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
+    {{- end }}
   selector:
     {{- include "global-chart.deploymentSelectorLabels" $labelCtx | nindent 4 }}
 {{- end }}

--- a/charts/global-chart/tests/service_test.yaml
+++ b/charts/global-chart/tests/service_test.yaml
@@ -178,3 +178,130 @@ tests:
       - equal:
           path: metadata.labels.team
           value: platform
+
+  # ====== extraPorts ======
+  - it: should render extraPorts after primary port
+    set:
+      deployments:
+        odoo:
+          image: odoo:17
+          service:
+            port: 8069
+            targetPort: 8069
+            portName: odoo
+            extraPorts:
+              - name: gevent
+                port: 8072
+                targetPort: 8072
+              - name: metrics
+                port: 9090
+                targetPort: 9090
+                protocol: TCP
+                appProtocol: http
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 8069
+      - equal:
+          path: spec.ports[0].name
+          value: odoo
+      - equal:
+          path: spec.ports[1].name
+          value: gevent
+      - equal:
+          path: spec.ports[1].port
+          value: 8072
+      - equal:
+          path: spec.ports[1].targetPort
+          value: 8072
+      - equal:
+          path: spec.ports[1].protocol
+          value: TCP
+      - equal:
+          path: spec.ports[2].name
+          value: metrics
+      - equal:
+          path: spec.ports[2].appProtocol
+          value: http
+      - lengthEqual:
+          path: spec.ports
+          count: 3
+
+  - it: should default extraPorts protocol to TCP when omitted
+    set:
+      deployments:
+        main:
+          image: nginx:1.25
+          service:
+            extraPorts:
+              - name: extra
+                port: 5353
+                targetPort: 5353
+    asserts:
+      - equal:
+          path: spec.ports[1].protocol
+          value: TCP
+
+  - it: should render UDP protocol on extraPorts when specified
+    set:
+      deployments:
+        main:
+          image: nginx:1.25
+          service:
+            extraPorts:
+              - name: dns
+                port: 5353
+                targetPort: 5353
+                protocol: UDP
+    asserts:
+      - equal:
+          path: spec.ports[1].protocol
+          value: UDP
+
+  - it: should render nodePort on extraPorts when set
+    set:
+      deployments:
+        main:
+          image: nginx:1.25
+          service:
+            type: NodePort
+            extraPorts:
+              - name: extra
+                port: 8081
+                targetPort: 8081
+                nodePort: 30081
+    asserts:
+      - equal:
+          path: spec.ports[1].nodePort
+          value: 30081
+
+  - it: should accept named targetPort in extraPorts
+    set:
+      deployments:
+        main:
+          image: nginx:1.25
+          service:
+            extraPorts:
+              - name: ws
+                port: 8072
+                targetPort: gevent
+    asserts:
+      - equal:
+          path: spec.ports[1].targetPort
+          value: gevent
+
+  - it: should render only primary port when extraPorts omitted
+    set:
+      deployments:
+        main:
+          image: nginx:1.25
+          service:
+            port: 8080
+            targetPort: 8080
+    asserts:
+      - lengthEqual:
+          path: spec.ports
+          count: 1
+      - equal:
+          path: spec.ports[0].port
+          value: 8080

--- a/charts/global-chart/values.schema.json
+++ b/charts/global-chart/values.schema.json
@@ -158,6 +158,30 @@
         "annotations": {
           "type": "object",
           "additionalProperties": { "type": "string" }
+        },
+        "extraPorts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+              "targetPort": {
+                "oneOf": [
+                  { "type": "string" },
+                  { "type": "integer", "minimum": 1, "maximum": 65535 }
+                ]
+              },
+              "protocol": {
+                "type": "string",
+                "enum": ["TCP", "UDP", "SCTP"]
+              },
+              "appProtocol": { "type": "string" },
+              "nodePort": { "type": "integer", "minimum": 30000, "maximum": 32767 }
+            },
+            "required": ["name", "port", "targetPort"],
+            "additionalProperties": false
+          }
         }
       },
       "additionalProperties": false

--- a/charts/global-chart/values.yaml
+++ b/charts/global-chart/values.yaml
@@ -79,6 +79,14 @@ deployments: {}
   #     targetPort: http
   #     # -- Protocol for the service port (TCP|UDP)
   #     protocol: TCP
+  #     # -- Additional ports exposed by the same Service (multi-port workloads)
+  #     # Each entry requires: name, port, targetPort. Optional: protocol, appProtocol, nodePort.
+  #     extraPorts: []
+  #     # extraPorts:
+  #     #   - name: gevent
+  #     #     port: 8072
+  #     #     targetPort: 8072
+  #     #     appProtocol: http
   #
   #   # -- Resource requests & limits for pods
   #   resources:

--- a/tests/bad-values/service-extra-ports-unknown-key.yaml
+++ b/tests/bad-values/service-extra-ports-unknown-key.yaml
@@ -1,0 +1,9 @@
+deployments:
+  main:
+    image: nginx:1.25
+    service:
+      extraPorts:
+        - name: gevent
+          port: 8072
+          targetPort: 8072
+          notARealKey: nope

--- a/tests/service-extra-ports.yaml
+++ b/tests/service-extra-ports.yaml
@@ -1,0 +1,22 @@
+# Test deployment with multi-port Service (Odoo HTTP + gevent pattern, see issue #52)
+deployments:
+  odoo:
+    image:
+      repository: odoo
+      tag: "17"
+    service:
+      type: ClusterIP
+      port: 8069
+      targetPort: 8069
+      portName: odoo
+      protocol: TCP
+      extraPorts:
+        - name: gevent
+          port: 8072
+          targetPort: 8072
+          protocol: TCP
+          appProtocol: http
+        - name: metrics
+          port: 9090
+          targetPort: metrics
+          protocol: TCP


### PR DESCRIPTION
## Summary

- Adds optional `extraPorts` list on the service object, rendered after the primary port (closes #52)
- Schema enforces required `[name, port, targetPort]` per item with `additionalProperties: false`; optional `protocol` (TCP/UDP/SCTP), `appProtocol`, `nodePort` (30000-32767)
- Bumps chart and `appVersion` to **1.6.0**
- Backward compatible: Services without `extraPorts` render byte-for-byte identical manifests

## Use case

Multi-port workloads on the same Pod selector: Odoo HTTP `8069` + gevent WebSocket `8072`, Redis client+TLS, gRPC sidecars, Prometheus exporters next to the main app.

```yaml
deployments:
  odoo:
    service:
      port: 8069
      targetPort: 8069
      portName: odoo
      extraPorts:
        - name: gevent
          port: 8072
          targetPort: 8072
          appProtocol: http
        - name: metrics
          port: 9090
          targetPort: metrics
```

## Changes

- `charts/global-chart/Chart.yaml` — bump `version` and `appVersion` to 1.6.0
- `charts/global-chart/values.schema.json` — `extraPorts` array in `$defs/service`
- `charts/global-chart/templates/service.yaml` — range after primary port (omits empty `appProtocol` / `nodePort`)
- `charts/global-chart/values.yaml` — document `extraPorts` in commented example block
- `charts/global-chart/README.md` — regenerated by helm-docs (version badge 1.6.0)
- `CHANGELOG.md` — 1.6.0 entry
- `charts/global-chart/tests/service_test.yaml` — 6 helm-unittest cases
- `tests/service-extra-ports.yaml` — lint scenario (Odoo pattern) added to `TEST_CASES`
- `tests/bad-values/service-extra-ports-unknown-key.yaml` — schema rejection for unknown sub-keys

## Test plan

- [x] `make lint-chart` — all scenarios pass including new `service-extra-ports`
- [x] `make unit-test` — 337/337 passed (was 331, +6)
- [x] `make validate-bad-values` — 5/5 rejected (was 4, +1)
- [x] `make kubeconform` — generated manifest valid against K8s 1.29
- [x] `make kube-linter` — no findings
- [x] `make generate-docs` — README badge updated to 1.6.0
- [x] Render verified: `generated-manifests/service-extra-ports/` shows primary `odoo:8069` + `gevent:8072` (appProtocol http) + `metrics:9090` (named targetPort)

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)