### PR TITLE
refactor(jobs): extract jobImageString + jobServiceAccount helpers (#54, #55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+#### Internal: job helper deduplication (issues #54, #55)
+
+Pure refactor — rendered manifests are byte-identical; error messages unchanged.
+
+- **`global-chart.jobImageString`** (`_job-helpers.tpl`): unifies the image-resolution choice (`explicit image > deploy.image > fromDeployment lookup+fail`) previously duplicated across four inline blocks in `cronjob.yaml` and `hook.yaml` (root + deployment-level). The `errCtx` argument preserves the exact `fromDeployment` failure messages.
+- **`global-chart.jobServiceAccount`** (`_job-helpers.tpl`): unifies the deployment-level ServiceAccount resolution (name/create/automount/annotations) previously duplicated near-verbatim across `hook.yaml` PART 2 and `cronjob.yaml` PART 2. Returns a JSON object consumed via `fromJson`.
+- Removed a dead `serviceAccount.automountServiceAccountToken` branch in the hook SA logic — the key is rejected by `values.schema.json` (`additionalProperties: false`), so it was unreachable. Automount is controlled by the job-level `automountServiceAccountToken` and the SA-map `automount` keys, unchanged.
+
+Deferred follow-ups tracked in #56 (`deploymentMetadata` helper) and #57 (`renderJob` collapse — needs an ADR).
+
+---
+
 ## [1.6.0] — 2026-05-21
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Global-chart is a reusable Helm chart (v1.5.0) providing multi-deployment Kubern
 ```bash
 make all                    # Full pipeline: lint + test + bad-values + generate + kubeconform + kube-linter
 make lint-chart             # Lint all 16 scenarios in tests/*.yaml
-make unit-test              # 331 helm-unittest tests (17 suites) via Docker
+make unit-test              # 338 helm-unittest tests (17 suites) via Docker
 make validate-bad-values    # Verify schema rejects invalid values
 make kubeconform            # Validate manifests against K8s 1.29
 make kube-linter            # Lint manifests (addAllBuiltIn)
@@ -38,7 +38,7 @@ When schema or user-visible values change (new fields, defaults, descriptions), 
 |------|--------|
 | `_helpers.tpl` | Core naming, labels (`fullname`, `deploymentFullname`, `labels`, `selectorLabels`, `deploymentEnabled`, `deploymentServiceAccountName`) |
 | `_image-helpers.tpl` | `imageString` (string/map/global registry/numeric tags), `imagePullPolicy` |
-| `_job-helpers.tpl` | `inheritedJobPodSpec` — shared pod spec for deployment-level hooks/cronjobs with full inheritance chain. Params: `inheritDnsConfig` (true=cronjob, false=hook), `renderInitContainers` (true=cronjob, false=hook) |
+| `_job-helpers.tpl` | `inheritedJobPodSpec` — shared pod spec for deployment-level hooks/cronjobs with full inheritance chain. Params: `inheritDnsConfig` (true=cronjob, false=hook), `renderInitContainers` (true=cronjob, false=hook). `jobImageString` — unified image resolution (`image` > `deploy.image` > `fromDeployment` lookup+fail), `errCtx` param preserves exact failure messages. `jobServiceAccount` — unified deployment-level SA resolution (name/create/automount/annotations), returns JSON consumed via `fromJson` |
 | `_render-helpers.tpl` | `renderVolume` (native + legacy), `renderImagePullSecrets`, `renderDnsConfig`, `renderResources`, `renderCommonAnnotations` |
 | `_validate-helpers.tpl` | `validateNameCollisions` — fails on truncation-induced name collisions |
 
@@ -119,3 +119,17 @@ imagePullSecrets:
 **Adding hook weight logic:** Maintain invariant `prereq (w-7) < SA (w-5) < Job (w)`
 
 **Every template must have a corresponding `*_test.yaml`** in `charts/global-chart/tests/`
+
+## Agent skills
+
+### Issue tracker
+
+Issues e PRD su GitHub Issues (`filippolmt/global-chart`), via `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Cinque ruoli canonici, label = nome del ruolo (default). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` + `docs/adr/` alla root. See `docs/agents/domain.md`.

--- a/charts/global-chart/templates/_job-helpers.tpl
+++ b/charts/global-chart/templates/_job-helpers.tpl
@@ -173,3 +173,110 @@ tolerations:
 {{- end }}
 restartPolicy: {{ default "Never" (ternary $job.restartPolicy "" (hasKey $job "restartPolicy")) | quote }}
 {{- end }}
+
+{{/*
+Resolve the image string for a cronjob/hook command, unifying the choice across
+root-level and deployment-level jobs. Returns the image string ("" when none
+resolves, so the caller applies `required` with its own context message).
+
+Accepts a dict with:
+  root    - top-level chart context
+  job     - the cronjob/hook command map
+  deploy  - the parent deployment map (omit/nil for root-level jobs)
+  errCtx  - prefix for the fromDeployment failure message (e.g. "cronJobs.cleanup")
+
+Resolution order:
+  1. explicit job.image
+  2. deploy.image            (deployment-level: inherit parent; takes precedence
+                              so a deployment-level job's fromDeployment is ignored,
+                              matching prior behavior)
+  3. job.fromDeployment      (root-level only: lookup + fail if missing)
+*/}}
+{{- define "global-chart.jobImageString" -}}
+{{- $root := .root -}}
+{{- $job := .job -}}
+{{- $deploy := .deploy -}}
+{{- $errCtx := .errCtx -}}
+{{- $global := $root.Values.global -}}
+{{- $img := "" -}}
+{{- if hasKey $job "image" -}}
+  {{- $img = include "global-chart.imageString" (dict "image" $job.image "global" $global) -}}
+{{- else if $deploy -}}
+  {{- $img = include "global-chart.imageString" (dict "image" $deploy.image "global" $global) -}}
+{{- else if $job.fromDeployment -}}
+  {{- $dep := index $root.Values.deployments $job.fromDeployment -}}
+  {{- if not $dep -}}
+    {{- fail (printf "%s.fromDeployment references deployment '%s' which does not exist in .Values.deployments" $errCtx $job.fromDeployment) -}}
+  {{- end -}}
+  {{- $img = include "global-chart.imageString" (dict "image" $dep.image "global" $global) -}}
+{{- end -}}
+{{- $img -}}
+{{- end -}}
+
+{{/*
+Resolve the ServiceAccount for a deployment-level cronjob/hook, unifying the
+resolution shared by hook.yaml PART 2 and cronjob.yaml PART 2.
+
+Helpers can only return strings, so this returns a JSON object; callers do
+`include ... | fromJson` and read .name/.create/.automount/.annotations.
+
+Accepts a dict with:
+  root         - top-level chart context
+  job          - the cronjob/hook command map
+  deploy       - the parent deployment map
+  deployName   - the deployment key
+  jobFullname  - the job's own resource name (fallback when a SA is created)
+
+Resolution:
+  name:   explicit (serviceAccountName | serviceAccount.name) > deployment SA > jobFullname
+  create: true only when no explicit/deployment SA applies, unless serviceAccount.create overrides
+  automount: serviceAccount.automount > job automountServiceAccountToken (default true)
+  annotations: SA-map annotations > job.serviceAccountAnnotations
+*/}}
+{{- define "global-chart.jobServiceAccount" -}}
+{{- $root := .root -}}
+{{- $job := .job -}}
+{{- $deploy := .deploy -}}
+{{- $deployName := .deployName -}}
+{{- $jobFullname := .jobFullname -}}
+{{- $deploySA := default (dict) $deploy.serviceAccount -}}
+{{- $jobSAMap := (and (hasKey $job "serviceAccount") (kindIs "map" $job.serviceAccount)) | ternary $job.serviceAccount (dict) -}}
+{{- $jobSAExplicitName := coalesce $job.serviceAccountName $jobSAMap.name -}}
+{{- /* Resolve deployment's SA name (created or referenced-existing) */ -}}
+{{- $deploymentSAName := "" -}}
+{{- $deploySACreate := ternary $deploySA.create true (hasKey $deploySA "create") -}}
+{{- if $deploySACreate -}}
+  {{- $deploymentSAName = include "global-chart.deploymentServiceAccountName" (dict "root" $root "deploymentName" $deployName "deployment" $deploy) -}}
+{{- else if $deploySA.name -}}
+  {{- $deploymentSAName = $deploySA.name -}}
+{{- end -}}
+{{- $saName := "" -}}
+{{- $saCreate := false -}}
+{{- if $jobSAExplicitName -}}
+  {{- $saName = $jobSAExplicitName -}}
+{{- else if $deploymentSAName -}}
+  {{- $saName = $deploymentSAName -}}
+{{- else -}}
+  {{- $saName = $jobFullname -}}
+  {{- $saCreate = true -}}
+{{- end -}}
+{{- /* Override saCreate if explicitly set in job */ -}}
+{{- if hasKey $jobSAMap "create" -}}
+  {{- $saCreate = $jobSAMap.create -}}
+  {{- if $saCreate -}}
+    {{- $saName = ternary $jobSAMap.name $jobFullname (hasKey $jobSAMap "name") -}}
+  {{- end -}}
+{{- end -}}
+{{- $saAutomount := true -}}
+{{- if hasKey $job "automountServiceAccountToken" -}}
+  {{- $saAutomount = $job.automountServiceAccountToken -}}
+{{- end -}}
+{{- if hasKey $jobSAMap "automount" -}}
+  {{- $saAutomount = $jobSAMap.automount -}}
+{{- end -}}
+{{- $saAnnotations := $job.serviceAccountAnnotations -}}
+{{- if hasKey $jobSAMap "annotations" -}}
+  {{- $saAnnotations = $jobSAMap.annotations -}}
+{{- end -}}
+{{- dict "name" $saName "create" $saCreate "automount" $saAutomount "annotations" $saAnnotations | toJson -}}
+{{- end -}}

--- a/charts/global-chart/templates/cronjob.yaml
+++ b/charts/global-chart/templates/cronjob.yaml
@@ -14,19 +14,8 @@
 {{- /* CronJob names limited to 52 chars (Jobs add 11-char timestamp suffix) */ -}}
 {{- $jobFullname := printf "%s-%s" $fullname $name | trunc 52 | trimSuffix "-" }}
 
-{{- /* Resolve image: explicit > fromDeployment > error */ -}}
-{{- $jobImage := "" }}
-{{- if hasKey $job "image" }}
-  {{- $jobImage = include "global-chart.imageString" (dict "image" $job.image "global" $root.Values.global) -}}
-{{- else if $job.fromDeployment }}
-  {{- $depName := $job.fromDeployment -}}
-  {{- $deploy := index $root.Values.deployments $depName -}}
-  {{- if not $deploy -}}
-    {{- fail (printf "cronJobs.%s.fromDeployment references deployment '%s' which does not exist in .Values.deployments" $name $depName) -}}
-  {{- end -}}
-  {{- $jobImage = include "global-chart.imageString" (dict "image" $deploy.image "global" $root.Values.global) -}}
-{{- end }}
-{{- $imageRef := required (printf "image is required for cronJobs.%s (set cronJobs.%s.image or cronJobs.%s.fromDeployment)" $name $name $name) $jobImage }}
+{{- /* Resolve image: explicit > fromDeployment > error (see jobImageString helper) */ -}}
+{{- $imageRef := required (printf "image is required for cronJobs.%s (set cronJobs.%s.image or cronJobs.%s.fromDeployment)" $name $name $name) (include "global-chart.jobImageString" (dict "root" $root "job" $job "errCtx" (printf "cronJobs.%s" $name))) }}
 
 {{- /* ServiceAccount - create own or use explicit name */ -}}
 {{- $saCreate := and (hasKey $job "serviceAccount") (hasKey $job.serviceAccount "create") $job.serviceAccount.create }}
@@ -211,62 +200,15 @@ spec:
 {{- /* CronJob names limited to 52 chars (Jobs add 11-char timestamp suffix) */ -}}
 {{- $jobFullname := printf "%s-%s-%s" (include "global-chart.fullname" $root) $deployName $name | trunc 52 | trimSuffix "-" }}
 
-{{- /* Resolve image: explicit in cronjob > inherited from deployment */ -}}
-{{- $jobImage := "" }}
-{{- if hasKey $job "image" }}
-  {{- $jobImage = include "global-chart.imageString" (dict "image" $job.image "global" $root.Values.global) -}}
-{{- else }}
-  {{- $jobImage = include "global-chart.imageString" (dict "image" $deploy.image "global" $root.Values.global) -}}
-{{- end }}
-{{- $imageRef := required (printf "image is required for deployments.%s.cronJobs.%s" $deployName $name) $jobImage }}
+{{- /* Resolve image: explicit in cronjob > inherited from deployment (see jobImageString helper) */ -}}
+{{- $imageRef := required (printf "image is required for deployments.%s.cronJobs.%s" $deployName $name) (include "global-chart.jobImageString" (dict "root" $root "job" $job "deploy" $deploy "errCtx" (printf "deployments.%s.cronJobs.%s" $deployName $name))) }}
 
-{{- /* ServiceAccount: explicit > inherited from deployment > default */ -}}
-{{- $deploySA := default (dict) $deploy.serviceAccount -}}
-{{- $jobSAMap := (and (hasKey $job "serviceAccount") (kindIs "map" $job.serviceAccount)) | ternary $job.serviceAccount (dict) -}}
-{{- $jobSAExplicitName := coalesce $job.serviceAccountName $jobSAMap.name -}}
-
-{{- /* Use deployment's SA name if it exists, otherwise cronjob's own SA */ -}}
-{{- $deploymentSAName := "" -}}
-{{- $deploySACreate := ternary $deploySA.create true (hasKey $deploySA "create") -}}
-{{- if $deploySACreate -}}
-  {{- $deploymentSAName = include "global-chart.deploymentServiceAccountName" (dict "root" $root "deploymentName" $deployName "deployment" $deploy) -}}
-{{- else if $deploySA.name -}}
-  {{- /* Deployment references an existing SA - inherit it */ -}}
-  {{- $deploymentSAName = $deploySA.name -}}
-{{- end -}}
-
-{{- $saName := "" -}}
-{{- $saCreate := false -}}
-{{- if $jobSAExplicitName -}}
-  {{- $saName = $jobSAExplicitName -}}
-{{- else if $deploymentSAName -}}
-  {{- /* Inherit from deployment's service account */ -}}
-  {{- $saName = $deploymentSAName -}}
-{{- else -}}
-  {{- /* Create cronjob-specific SA */ -}}
-  {{- $saName = $jobFullname -}}
-  {{- $saCreate = true -}}
-{{- end -}}
-
-{{- /* Override saCreate if explicitly set in job */ -}}
-{{- if hasKey $jobSAMap "create" -}}
-  {{- $saCreate = $jobSAMap.create -}}
-  {{- if $saCreate -}}
-    {{- $saName = ternary $jobSAMap.name $jobFullname (hasKey $jobSAMap "name") -}}
-  {{- end -}}
-{{- end -}}
-
-{{- $saAutomount := true -}}
-{{- if hasKey $job "automountServiceAccountToken" -}}
-  {{- $saAutomount = $job.automountServiceAccountToken -}}
-{{- end -}}
-{{- if hasKey $jobSAMap "automount" -}}
-  {{- $saAutomount = $jobSAMap.automount -}}
-{{- end -}}
-{{- $saAnnotations := $job.serviceAccountAnnotations -}}
-{{- if hasKey $jobSAMap "annotations" -}}
-  {{- $saAnnotations = $jobSAMap.annotations -}}
-{{- end -}}
+{{- /* ServiceAccount: explicit > inherited from deployment > default (see jobServiceAccount helper) */ -}}
+{{- $sa := include "global-chart.jobServiceAccount" (dict "root" $root "job" $job "deploy" $deploy "deployName" $deployName "jobFullname" $jobFullname) | fromJson -}}
+{{- $saName := $sa.name -}}
+{{- $saCreate := $sa.create -}}
+{{- $saAutomount := $sa.automount -}}
+{{- $saAnnotations := $sa.annotations -}}
 
 {{- /* Create SA only if needed (not using deployment's or explicit existing) */ -}}
 {{- if $saCreate }}

--- a/charts/global-chart/templates/hook.yaml
+++ b/charts/global-chart/templates/hook.yaml
@@ -13,19 +13,8 @@
 {{- if $command }}
 {{- $hookFullname := include "global-chart.hookfullname" (merge (dict "hookname" $hookType "jobname" $name) $root) }}
 
-{{- /* Resolve image: explicit > fromDeployment > error */ -}}
-{{- $cmdImage := "" }}
-{{- if hasKey $command "image" }}
-  {{- $cmdImage = include "global-chart.imageString" (dict "image" $command.image "global" $root.Values.global) -}}
-{{- else if $command.fromDeployment }}
-  {{- $depName := $command.fromDeployment -}}
-  {{- $deploy := index $root.Values.deployments $depName -}}
-  {{- if not $deploy -}}
-    {{- fail (printf "hooks.%s.%s.fromDeployment references deployment '%s' which does not exist in .Values.deployments" $hookType $name $depName) -}}
-  {{- end -}}
-  {{- $cmdImage = include "global-chart.imageString" (dict "image" $deploy.image "global" $root.Values.global) -}}
-{{- end }}
-{{- $imageRef := required (printf "image is required for hooks.%s.%s (set hooks.%s.%s.image or hooks.%s.%s.fromDeployment)" $hookType $name $hookType $name $hookType $name) $cmdImage }}
+{{- /* Resolve image: explicit > fromDeployment > error (see jobImageString helper) */ -}}
+{{- $imageRef := required (printf "image is required for hooks.%s.%s (set hooks.%s.%s.image or hooks.%s.%s.fromDeployment)" $hookType $name $hookType $name $hookType $name) (include "global-chart.jobImageString" (dict "root" $root "job" $command "errCtx" (printf "hooks.%s.%s" $hookType $name))) }}
 
 {{- /* ServiceAccount handling */ -}}
 {{- $commandSAMap := (and (hasKey $command "serviceAccount") (kindIs "map" $command.serviceAccount)) | ternary $command.serviceAccount (dict) -}}
@@ -284,71 +273,15 @@ data:
 {{- /* Build hook fullname with deployment name for uniqueness */ -}}
 {{- $hookFullname := printf "%s-%s-%s-%s" (include "global-chart.fullname" $root) $deployName $hookType $name | trunc 63 | trimSuffix "-" }}
 
-{{- /* Resolve image: explicit in hook > inherited from deployment */ -}}
-{{- $cmdImage := "" }}
-{{- if hasKey $command "image" }}
-  {{- $cmdImage = include "global-chart.imageString" (dict "image" $command.image "global" $root.Values.global) -}}
-{{- else }}
-  {{- $cmdImage = include "global-chart.imageString" (dict "image" $deploy.image "global" $root.Values.global) -}}
-{{- end }}
-{{- $imageRef := required (printf "image is required for deployments.%s.hooks.%s.%s" $deployName $hookType $name) $cmdImage }}
+{{- /* Resolve image: explicit in hook > inherited from deployment (see jobImageString helper) */ -}}
+{{- $imageRef := required (printf "image is required for deployments.%s.hooks.%s.%s" $deployName $hookType $name) (include "global-chart.jobImageString" (dict "root" $root "job" $command "deploy" $deploy "errCtx" (printf "deployments.%s.hooks.%s.%s" $deployName $hookType $name))) }}
 
-{{- /* ServiceAccount: explicit in hook > inherited from deployment > create new for hook */ -}}
-{{- $deploySA := default (dict) $deploy.serviceAccount -}}
-{{- $commandSAMap := (and (hasKey $command "serviceAccount") (kindIs "map" $command.serviceAccount)) | ternary $command.serviceAccount (dict) -}}
-{{- $commandSAExplicitName := coalesce $command.serviceAccountName $commandSAMap.name -}}
-
-{{- /*
-  Resolve deployment's SA name:
-  - If deployment has serviceAccount.create=true, use generated or specified name
-  - If deployment has serviceAccount.name but create=false, use that existing name
-  - Otherwise no deployment SA to inherit
-*/ -}}
-{{- $deploymentSAName := "" -}}
-{{- $deploySACreate := ternary $deploySA.create true (hasKey $deploySA "create") -}}
-{{- if $deploySACreate -}}
-  {{- $deploymentSAName = include "global-chart.deploymentServiceAccountName" (dict "root" $root "deploymentName" $deployName "deployment" $deploy) -}}
-{{- else if $deploySA.name -}}
-  {{- /* Deployment references an existing SA - inherit it */ -}}
-  {{- $deploymentSAName = $deploySA.name -}}
-{{- end -}}
-
-{{- $saName := "" -}}
-{{- $saCreate := false -}}
-{{- if $commandSAExplicitName -}}
-  {{- /* Hook explicitly specifies a SA name - use it */ -}}
-  {{- $saName = $commandSAExplicitName -}}
-{{- else if $deploymentSAName -}}
-  {{- /* Inherit from deployment's service account (whether created or existing) */ -}}
-  {{- $saName = $deploymentSAName -}}
-{{- else -}}
-  {{- /* No SA from hook or deployment - create hook-specific SA */ -}}
-  {{- $saName = $hookFullname -}}
-  {{- $saCreate = true -}}
-{{- end -}}
-
-{{- /* Override saCreate if explicitly set in command */ -}}
-{{- if hasKey $commandSAMap "create" -}}
-  {{- $saCreate = $commandSAMap.create -}}
-  {{- if $saCreate -}}
-    {{- $saName = ternary $commandSAMap.name $hookFullname (hasKey $commandSAMap "name") -}}
-  {{- end -}}
-{{- end -}}
-
-{{- $saAutomount := true -}}
-{{- if hasKey $command "automountServiceAccountToken" -}}
-  {{- $saAutomount = $command.automountServiceAccountToken -}}
-{{- end -}}
-{{- if hasKey $commandSAMap "automountServiceAccountToken" -}}
-  {{- $saAutomount = $commandSAMap.automountServiceAccountToken -}}
-{{- end -}}
-{{- if hasKey $commandSAMap "automount" -}}
-  {{- $saAutomount = $commandSAMap.automount -}}
-{{- end -}}
-{{- $saAnnotations := $command.serviceAccountAnnotations -}}
-{{- if hasKey $commandSAMap "annotations" -}}
-  {{- $saAnnotations = $commandSAMap.annotations -}}
-{{- end -}}
+{{- /* ServiceAccount: explicit in hook > inherited from deployment > create new for hook (see jobServiceAccount helper) */ -}}
+{{- $sa := include "global-chart.jobServiceAccount" (dict "root" $root "job" $command "deploy" $deploy "deployName" $deployName "jobFullname" $hookFullname) | fromJson -}}
+{{- $saName := $sa.name -}}
+{{- $saCreate := $sa.create -}}
+{{- $saAutomount := $sa.automount -}}
+{{- $saAnnotations := $sa.annotations -}}
 
 {{- /* Create SA only if needed (not using deployment's or explicit existing);
        ServiceAccount uses weight 5 so it exists before the Job (weight 10) */ -}}

--- a/charts/global-chart/tests/cronjob_test.yaml
+++ b/charts/global-chart/tests/cronjob_test.yaml
@@ -558,6 +558,29 @@ tests:
           value: false
         documentIndex: 0
 
+  - it: should honor serviceAccount.automount on created deployment-level cronjob SA
+    release:
+      name: myrel
+    set:
+      deployments:
+        backend:
+          image: myapp/backend:v1
+          cronJobs:
+            cleanup:
+              schedule: "0 4 * * *"
+              command: ["./cleanup.sh"]
+              serviceAccount:
+                create: true
+                automount: false
+    asserts:
+      - isKind:
+          of: ServiceAccount
+        documentIndex: 0
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+        documentIndex: 0
+
   - it: should render successfulJobsHistoryLimit 0 on deployment-level cronjob
     set:
       deployments:


### PR DESCRIPTION
## Summary
Pure refactor — deduplicates image-resolution and deployment-level ServiceAccount-resolution logic copy-pasted across `cronjob.yaml` and `hook.yaml`.

- **`jobImageString`** (`_job-helpers.tpl`): unifies `image > deploy.image > fromDeployment lookup+fail` across the four inline blocks. `errCtx` arg preserves the exact `fromDeployment` failure messages asserted by tests.
- **`jobServiceAccount`** (`_job-helpers.tpl`): unifies the deployment-level SA name/create/automount/annotations resolution shared by hook PART 2 and cronjob PART 2. Returns JSON consumed via `fromJson`.
- Removed a dead `serviceAccount.automountServiceAccountToken` branch in the hook SA logic — the key is rejected by `values.schema.json` (`additionalProperties: false`), so it was unreachable.

## Safety
- Rendered manifests **byte-identical**, error messages unchanged.
- `make all` green (lint 16 scenarios, kubeconform K8s 1.29, kube-linter).
- **338/338** unit tests (337 + 1 new locking `serviceAccount.automount` on a created deployment-level cronjob SA).

## Release
Chart version intentionally kept at **1.6.0** (changelog under `[Unreleased]`) so merging this PR does **not** cut a release — `chart-releaser` skips the existing `global-chart-1.6.0`. The version bump + release happens in the final PR.

## Closes
Closes #54, closes #55. Deferred: #56 (`deploymentMetadata`), #57 (`renderJob`, needs ADR).