### PR TITLE
feat!: drop appVersion; emit version label only when set

### DIFF
--- a/.claude/skills/global-chart-development/SKILL.md
+++ b/.claude/skills/global-chart-development/SKILL.md
@@ -1,15 +1,22 @@
 ---
 name: global-chart-development
-description: Use when modifying global-chart Helm templates, adding features, fixing bugs, refactoring helpers, or updating values, CHANGELOG, or Chart.yaml in this repo. Covers hasKey vs truthiness pitfalls, global fallback chains, inheritance logic (with defensive opt-out toggles), validation with fail, deterministic rendering, schema integer bounds, empty metadata block pitfall, resource-name helpers (one home per name so templates and the collision validator never drift on truncation), the discipline of proving a bug is observable before labelling it a `fix:`, and the required lint-test-generate workflow.
+description: Use for any hands-on work on this repo's `global-chart` Helm chart — editing, adding, fixing, refactoring, or testing it. Covers exposing a new Kubernetes field (e.g. priorityClassName, topologySpreadConstraints) on a deployment/cronjob/hook; adding `fail`-based validation for invalid or mutually-exclusive config (e.g. PDB minAvailable + maxUnavailable); refactoring or deduplicating helpers in `_helpers.tpl`/`_job-helpers.tpl`; debugging chart rendering (`enabled: false` ignored, name collisions, misbehaving hooks); fixing failing helm-unittest suites after a `.tpl` change; and touching `values.yaml`, `values.schema.json`, tests, `CHANGELOG`, or `Chart.yaml`. Provides the template+test+schema+version co-change, lint/unit-test/generate workflow, conventional-commit and prove-before-`fix:` discipline, and chart-specific patterns not in CLAUDE.md. Do NOT use for generic Helm/Kubernetes how-to, installing charts, formatting files, or explaining an existing helper without changing it.
 ---
 
 # Global-Chart Development Patterns
 
-Coding patterns extracted from the global-chart repository.
+Procedural disciplines and the patterns that are NOT already in `CLAUDE.md`.
+
+> **Core template coding rules live in `CLAUDE.md`** (always loaded): `hasKey` vs
+> `default` for bool/numeric, never mutate `.Values`, nil-safe nested access,
+> `with`-wrap empty helpers, global fallback chains, multi-deployment iteration,
+> schema↔template consistency, resource naming limits. This skill does NOT repeat
+> them — it adds the workflow, the commit/fix discipline, and the project-specific
+> patterns below.
 
 ## Commit Conventions
 
-This project uses **conventional commits** (~65% adoption):
+This project uses **conventional commits**:
 
 | Prefix | Usage |
 |--------|-------|
@@ -50,7 +57,7 @@ accordingly, don't dress it up as a bug regression.
 1. `charts/global-chart/templates/<resource>.yaml` — the template
 2. `charts/global-chart/tests/<resource>_test.yaml` — unit tests
 3. `charts/global-chart/Chart.yaml` — version bump (patch for fixes, minor for features)
-4. `CLAUDE.md` — update test count, architecture docs if changed
+4. `CLAUDE.md` — update architecture docs if changed (do NOT add fixed counts; CLAUDE.md is kept number-free so it can't drift)
 
 **Version bump also requires:** `charts/global-chart/values.yaml` annotation updates → `make generate-docs`
 
@@ -73,87 +80,9 @@ moved and it isn't a pure refactor; either that's a real (and intended) behaviou
 change you should call out, or a mistake. New tests are fine; *changed* old
 expectations are the signal to stop and look.
 
-## Helm Template Gotchas (Project-Specific)
+## Project-Specific Patterns (not in CLAUDE.md)
 
-### Boolean Fields: Never Use `default`
-
-Go templates treat `false` as falsy. `default true .field` replaces `false` with `true`.
-
-```yaml
-# ❌ WRONG: loses explicit false
-enabled: {{ default true $deploy.enabled }}
-
-# ✅ CORRECT: preserves false
-enabled: {{ hasKey $deploy "enabled" | ternary $deploy.enabled true }}
-```
-
-Use the centralized helper when available:
-```yaml
-{{- if eq (include "global-chart.deploymentEnabled" (dict "deploy" $deploy)) "true" }}
-```
-
-### Never Mutate .Values
-
-```yaml
-# ❌ WRONG: mutates shared state
-{{- $_ := set $ing.annotations "key" "value" }}
-
-# ✅ CORRECT: work on a copy
-{{- $annotations := deepCopy $ing.annotations }}
-{{- $_ := set $annotations "key" "value" }}
-```
-
-### Inheritance: Use hasKey to Distinguish "Not Set" from "Empty"
-
-For hooks/cronjobs inside deployments that inherit from parent:
-
-```yaml
-# ❌ WRONG: treats {} and [] as falsy, incorrectly inherits
-{{- if not $job.field }}{{ $deploy.field }}{{- end }}
-
-# ✅ CORRECT: only inherits when field is truly absent
-{{ hasKey $job "field" | ternary $job.field $deploy.field }}
-```
-
-### Global Fallback Chains: hasKey at Every Level
-
-When falling back through job → deployment → global (e.g., imagePullSecrets), use `hasKey` at each level. An explicit empty list (`imagePullSecrets: []`) must stop the fallback — it means "no pull secrets", not "unset".
-
-```yaml
-# ❌ WRONG: [] is falsy, falls through to global
-{{- $imagePullSecrets := $job.imagePullSecrets -}}
-{{- if not $imagePullSecrets -}}
-  {{- $imagePullSecrets = $global.imagePullSecrets -}}
-{{- end -}}
-
-# ✅ CORRECT: hasKey at each level
-{{- $imagePullSecrets := list -}}
-{{- if hasKey $job "imagePullSecrets" -}}
-  {{- $imagePullSecrets = $job.imagePullSecrets -}}
-{{- else if hasKey $deploy "imagePullSecrets" -}}
-  {{- $imagePullSecrets = $deploy.imagePullSecrets -}}
-{{- else -}}
-  {{- $imagePullSecrets = $global.imagePullSecrets -}}
-{{- end -}}
-```
-
-### Numeric Fields: Never Use Truthiness
-
-Go templates treat `0` as falsy. For fields like PDB `minAvailable`/`maxUnavailable`, use `hasKey`:
-
-```yaml
-# ❌ WRONG: 0 is falsy, won't render
-{{- if $pdb.minAvailable }}
-minAvailable: {{ $pdb.minAvailable }}
-{{- end }}
-
-# ✅ CORRECT: hasKey preserves 0
-{{- if hasKey $pdb "minAvailable" }}
-minAvailable: {{ $pdb.minAvailable }}
-{{- end }}
-```
-
-### Template Validation with fail
+### Template Validation with `fail`
 
 Use `fail` for invalid configurations instead of silently producing bad manifests:
 
@@ -167,17 +96,6 @@ Use `fail` for invalid configurations instead of silently producing bad manifest
 {{- else }}
 {{- fail (printf "unknown type '%s' for volume '%s'" $vol.type $vol.name) }}
 {{- end }}
-```
-
-### Nil-Safe Nested Access
-
-```yaml
-# ❌ WRONG: nil pointer if parent missing
-{{ $deploy.service.port }}
-
-# ✅ CORRECT: safe default
-{{- $service := default (dict) $deploy.service }}
-{{ $service.port }}
 ```
 
 ### Native Volumes: Deterministic Key Ordering
@@ -270,39 +188,6 @@ Always pair a tightened minimum with a `tests/bad-values/` fixture so CI keeps t
 {{- end -}}
 ```
 
-## Multi-Deployment Iteration Pattern
-
-All resource templates iterate over the deployments map:
-
-```yaml
-{{- range $name, $deploy := .Values.deployments }}
-{{- if eq (include "global-chart.deploymentEnabled" (dict "deploy" $deploy)) "true" }}
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: {{ include "global-chart.deploymentFullname" (dict "root" $ "name" $name) }}
-  labels:
-    {{- include "global-chart.labels" $ | nindent 4 }}
-    app.kubernetes.io/component: {{ $name }}
-# ... template body ...
-{{- end }}
-{{- end }}
-```
-
-Key points:
-- `$name` = deployment key (frontend, backend, worker)
-- `$deploy` = deployment config map
-- Always pass `$` (root context) to helpers, not `.`
-- `app.kubernetes.io/component` ensures unique selectors per deployment
-
-## Resource Naming Limits
-
-| Resource | Max Chars | Why |
-|----------|-----------|-----|
-| Most resources | 63 | Kubernetes label limit |
-| CronJobs | **52** | K8s appends 11-char timestamp to Job names |
-
 ### One Helper Per Name — Never Recompute a Name Inline
 
 A resource name is computed from a `printf | trunc N | trimSuffix "-"` rule. The
@@ -319,10 +204,7 @@ name the template never emits.
 
 Give every resource name exactly one home: a named helper in `_helpers.tpl` that
 owns the `printf`, the truncation constant, and the `trimSuffix`. Both the
-emitting template and the validator call that helper. Now the name can't drift,
-the magic truncation constant lives in one place, and changing the rule is a
-one-line edit. This mirrors how `deploymentFullname` / `hookfullname` already
-work — extend the pattern, don't reinvent it inline.
+emitting template and the validator call that helper.
 
 ```yaml
 # ❌ WRONG: same rule typed in cronjob.yaml AND _validate-helpers.tpl
@@ -338,9 +220,8 @@ the template and (if it participates in collision detection) the validator.
 ## Test Structure
 
 - **`tests/`** (root): Value files for lint scenarios (`make lint-chart`)
-- **`charts/global-chart/tests/`**: helm-unittest suites (`make unit-test`)
+- **`charts/global-chart/tests/`**: helm-unittest suites (`make unit-test`) — one `*_test.yaml` per template; `make unit-test` prints the live suite/test totals
 - **`tests/bad-values/`**: fixtures that MUST be rejected by `values.schema.json` (`make validate-bad-values`)
-- **17 suites** under `charts/global-chart/tests/` (exact test count lives in CLAUDE.md — single source of truth)
 
 When adding a new template, always create a corresponding `*_test.yaml`.
 When adding a schema constraint that should reject configurations, add a fixture in `tests/bad-values/` so the schema's rejection is locked in by CI.
@@ -354,6 +235,7 @@ When adding a schema constraint that should reject configurations, add a fixture
 5. **ServiceAccount per deployment by default**: `serviceAccount.create` defaults to `true`
 6. **Schema as first line of defense**: every template-accessed field is declared in `values.schema.json`; integer bounds reject obviously-invalid values (e.g. `completions: 0`) before the API server does
 7. **Docker-based tooling**: helm-unittest and helm-docs run via Docker, no local plugins needed
+8. **No `appVersion`**: generic chart, no app version to pin; `app.kubernetes.io/version` is emitted only when set (consumers add it via `global.commonLabels`)
 
 ## New-Field Checklist
 
@@ -366,4 +248,4 @@ When exposing a new Kubernetes spec field on a chart resource, walk through:
 5. **Tests** (`charts/global-chart/tests/<resource>_test.yaml`): three cases minimum — field set & rendered, field absent & not rendered, edge value (0, false, empty) rendered correctly.
 6. **Bad-values** (`tests/bad-values/`): fixture for any schema constraint you tightened.
 7. **CHANGELOG.md** + Chart.yaml version bump (patch for fixes, minor for opt-in features).
-8. **CLAUDE.md**: update test count and any architecture changes; refresh the Helper Files table if you added one.
+8. **CLAUDE.md**: update architecture changes; refresh the Helper Files table if you added one. (No fixed counts — keep it number-free.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ---
 
-## [Unreleased]
+## [2.0.0] — 2026-06-28
 
 ### Added
 - `externalSecrets.<name>.data` (list form): many remote keys collapsed into a
@@ -32,6 +32,29 @@ externalSecrets:
     dataFrom:
       - find: { name: { regexp: "^APP_.*" } }
 ```
+
+### Changed
+- Removed `appVersion` from `Chart.yaml`. This is a generic, reusable chart that
+  deploys arbitrary workloads, so there is no single application version to pin.
+- The `app.kubernetes.io/version` label is now emitted only when set — it is no
+  longer hardcoded to the chart's `appVersion`. Consumers that want it can set
+  it via `global.commonLabels` (e.g. `app.kubernetes.io/version: "2.3.4"`).
+
+### ⚠️ Breaking — rendered-output change
+- **`app.kubernetes.io/version` is no longer present on rendered objects by
+  default.** Every resource previously carried this recommended label set to the
+  chart's `appVersion`; after upgrading it disappears unless you set it yourself.
+- **Impact:** dashboards, alerting rules, cost-allocation, and any `kubectl`/
+  tooling queries that *filter on* `app.kubernetes.io/version` return empty or
+  mismatched results after upgrade. **Pod/Service selectors are NOT affected** —
+  they only ever matched `name`/`instance`/`component`, so rollouts are safe.
+- **Migration:** if you relied on the label, re-add it explicitly via
+  `global.commonLabels`:
+  ```yaml
+  global:
+    commonLabels:
+      app.kubernetes.io/version: "<your-app-version>"
+  ```
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Global-chart is a reusable Helm chart (v1.5.0) providing multi-deployment Kubern
 ```bash
 make all                    # Full pipeline: lint + test + bad-values + generate + kubeconform + kube-linter
 make lint-chart             # Lint all 16 scenarios in tests/*.yaml
-make unit-test              # 387 helm-unittest tests (19 suites) via Docker
+make unit-test              # 389 helm-unittest tests (19 suites) via Docker
 make validate-bad-values    # Verify schema rejects invalid values
 make kubeconform            # Validate manifests against K8s 1.29
 make kube-linter            # Lint manifests (addAllBuiltIn)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,14 +4,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Global-chart is a reusable Helm chart (v1.5.0) providing multi-deployment Kubernetes building blocks. See `README.md` for full feature list and examples, `CHANGELOG.md` for version history and migration guides.
+Global-chart is a reusable Helm chart providing multi-deployment Kubernetes building blocks. See `Chart.yaml` for the current version, `README.md` for the full feature list and examples, `CHANGELOG.md` for version history and migration guides.
 
 ## Commands
 
 ```bash
 make all                    # Full pipeline: lint + test + bad-values + generate + kubeconform + kube-linter
-make lint-chart             # Lint all 16 scenarios in tests/*.yaml
-make unit-test              # 389 helm-unittest tests (19 suites) via Docker
+make lint-chart             # Lint every scenario in TEST_CASES (Makefile)
+make unit-test              # Run helm-unittest suites via Docker
 make validate-bad-values    # Verify schema rejects invalid values
 make kubeconform            # Validate manifests against K8s 1.29
 make kube-linter            # Lint manifests (addAllBuiltIn)
@@ -27,9 +27,9 @@ When schema or user-visible values change (new fields, defaults, descriptions), 
 ### File Layout
 
 - `charts/global-chart/templates/` — Helm templates
-- `charts/global-chart/templates/_*.tpl` — Helper files (5 domain files, see below)
+- `charts/global-chart/templates/_*.tpl` — Helper files (domain-split, see below)
 - `charts/global-chart/values.schema.json` — JSON Schema Draft 7
-- `charts/global-chart/tests/` — helm-unittest suites (19 suites)
+- `charts/global-chart/tests/` — helm-unittest suites (one `*_test.yaml` per template)
 - `tests/` — Lint scenario values + `bad-values/` for schema rejection tests
 
 ### Helper Files
@@ -54,6 +54,7 @@ When schema or user-visible values change (new fields, defaults, descriptions), 
 7. **Hook prerequisite resources**: Deployment ConfigMap/Secret are duplicated as hook-annotated resources because normal resources aren't updated until after hooks complete
 8. **Global fallback chains**: job > deployment > global, using `hasKey` at every level. Explicit `[]` stops fallback
 9. **Schema**: `values.schema.json` validates during install/upgrade/lint. Does NOT use `required` on `mountedConfigFiles` items (templates handle runtime validation to allow `failedTemplate` tests)
+10. **No `appVersion`**: this is a generic chart with no app version to pin. `app.kubernetes.io/version` is emitted only when set — guarded with `{{- with .Chart.AppVersion }}` in the label helpers; consumers set it via `global.commonLabels`. Pod/Service selectors never included it.
 
 ### Resource Naming Limits
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The chart supports **multiple deployments** in a single release, each with indep
   - **Inside deployments** (`deployments.*.hooks`, `deployments.*.cronJobs`): Inherit image, configMap, secret, serviceAccount, hostAliases, podSecurityContext, securityContext, dnsConfig (cronJobs), nodeSelector, tolerations, affinity, and more from the parent deployment
   - Hook prerequisite ConfigMap/Secret are created automatically with correct weight ordering
 - **Secret management**
-  ExternalSecret resources with required field validation to avoid silent misconfigurations.
+  ExternalSecret resources with required field validation to avoid silent misconfigurations. Each entry maps a single remote key (`remote`/`secretkey`), many keys into one Secret via a `data` list, or pulls in bulk via `dataFrom` (`extract`/`find`).
 - **RBAC**
   Create Roles, ServiceAccounts, and RoleBindings for fine-grained access control.
 - **Global values**

--- a/README.md
+++ b/README.md
@@ -122,11 +122,11 @@ make render VALUES=tests/test01/values.01.yaml TEMPLATE=deployment.yaml
 
 The chart has multiple layers of testing:
 
-- **Lint scenarios** (`make lint-chart`): Runs `helm lint --strict` across 17 value files in `tests/`.
-- **Unit tests** (`make unit-test`): 312 helm-unittest tests across 17 suites in `charts/global-chart/tests/`, including negative `failedTemplate` tests.
-- **Schema validation** (`make validate-bad-values`): Verifies schema correctly rejects 3 invalid value files.
-- **Manifest validation** (`make kubeconform`): Validates 161 generated resources against K8s 1.29 schema.
-- **Best practices** (`make kube-linter`): Lints manifests with `addAllBuiltIn: true` and 28 documented exclusions.
+- **Lint scenarios** (`make lint-chart`): Runs `helm lint --strict` across every scenario in `tests/` (the `TEST_CASES` list in the `Makefile`).
+- **Unit tests** (`make unit-test`): helm-unittest suites in `charts/global-chart/tests/` (one `*_test.yaml` per template), including negative `failedTemplate` tests.
+- **Schema validation** (`make validate-bad-values`): Verifies the schema rejects every fixture in `tests/bad-values/`.
+- **Manifest validation** (`make kubeconform`): Validates the generated resources against the K8s 1.29 schema.
+- **Best practices** (`make kube-linter`): Lints manifests with `addAllBuiltIn: true` and the documented exclusions.
 
 The GitHub Action (`.github/workflows/helm-ci.yml`) executes all steps on pushes and pull requests, pre-pulling Docker images with retry for resilience.
 

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -1,7 +1,7 @@
 {{ template "chart.header" . }}
 {{ template "chart.description" . }}
 
-{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}
 
 {{ template "chart.requirementsSection" . }}
 

--- a/charts/global-chart/Chart.yaml
+++ b/charts/global-chart/Chart.yaml
@@ -13,12 +13,14 @@ description: "Reusable Helm chart providing common building blocks—Deployments
 type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
+# to the chart and its templates.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.0
+version: 2.0.0
 
-# Application version deployed by this chart
-appVersion: "1.7.0"
+# appVersion is intentionally omitted: this is a generic, reusable chart that
+# deploys arbitrary workloads, so there is no single application version to pin.
+# The app.kubernetes.io/version label is therefore only emitted when a consumer
+# sets it (e.g. via global.commonLabels).
 
 # Chart icon
 icon: https://helm.sh/img/helm.svg

--- a/charts/global-chart/README.md
+++ b/charts/global-chart/README.md
@@ -1,6 +1,6 @@
 # global-chart
 
-![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Reusable Helm chart providing common building blocks—Deployments, Services, Ingress, Jobs, and more—for broadly adaptable Kubernetes applications.
 

--- a/charts/global-chart/templates/_helpers.tpl
+++ b/charts/global-chart/templates/_helpers.tpl
@@ -36,7 +36,9 @@ Common labels (for non-deployment resources like Ingress)
 {{- define "global-chart.labels" -}}
 helm.sh/chart: {{ include "global-chart.chart" . }}
 {{ include "global-chart.selectorLabels" . }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- with .Chart.AppVersion }}
+app.kubernetes.io/version: {{ . | quote }}
+{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- $global := default (dict) .Values.global }}
 {{- with $global.commonLabels }}
@@ -80,7 +82,9 @@ Usage: {{ include "global-chart.deploymentLabels" (dict "root" . "deploymentName
 {{- define "global-chart.deploymentLabels" -}}
 helm.sh/chart: {{ include "global-chart.chart" .root }}
 {{ include "global-chart.deploymentSelectorLabels" . }}
-app.kubernetes.io/version: {{ .root.Chart.AppVersion | quote }}
+{{- with .root.Chart.AppVersion }}
+app.kubernetes.io/version: {{ . | quote }}
+{{- end }}
 app.kubernetes.io/managed-by: {{ .root.Release.Service }}
 {{- $global := default (dict) .root.Values.global }}
 {{- with $global.commonLabels }}
@@ -120,7 +124,9 @@ Base labels without component (used when component is added separately).
 */}}
 {{- define "global-chart.hookLabels" -}}
 helm.sh/chart: {{ include "global-chart.chart" . }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- with .Chart.AppVersion }}
+app.kubernetes.io/version: {{ . | quote }}
+{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- $global := default (dict) .Values.global }}
 {{- with $global.commonLabels }}

--- a/charts/global-chart/tests/helpers_test.yaml
+++ b/charts/global-chart/tests/helpers_test.yaml
@@ -114,14 +114,39 @@ tests:
           value: Always
 
   # ====== version label ======
-  - it: should include version label in deployment labels
+  - it: should omit the version label when appVersion is unset (generic chart)
     set:
       deployments:
         main:
           image: "nginx:1.25"
     asserts:
-      - isNotEmpty:
+      - notExists:
           path: metadata.labels["app.kubernetes.io/version"]
+
+  - it: should let a consumer set the version label via global.commonLabels
+    set:
+      global:
+        commonLabels:
+          app.kubernetes.io/version: "2.3.4"
+      deployments:
+        main:
+          image: "nginx:1.25"
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/version"]
+          value: "2.3.4"
+
+  - it: should emit the version label (quoted) when the chart defines appVersion
+    chart:
+      appVersion: "9.9.9"
+    set:
+      deployments:
+        main:
+          image: "nginx:1.25"
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/version"]
+          value: "9.9.9"
 
   # ====== global.commonLabels in labels helpers ======
   - it: should include global.commonLabels in deployment labels


### PR DESCRIPTION
## What

`global-chart` is a generic, reusable chart that deploys arbitrary workloads — there is no single application version to pin. `appVersion` was meaningless here and forced a hardcoded `app.kubernetes.io/version` label (the chart's own appVersion) onto every rendered resource.

## Changes

- Remove `appVersion` from `Chart.yaml`.
- Emit `app.kubernetes.io/version` **only when set** — guarded with `{{- with .Chart.AppVersion }}` in the three label helpers (`labels`, `deploymentLabels`, `hookLabels`). Consumers who want it set it via `global.commonLabels` (e.g. `app.kubernetes.io/version: "2.3.4"`).
- Drop the appVersion badge from `README.md.gotmpl`; regenerate docs.

## ⚠️ Breaking (→ 2.0.0)

`app.kubernetes.io/version` no longer appears on rendered objects by default. Dashboards / alerts / cost-allocation / `kubectl` queries that **filter on** that label return empty after upgrade. **Pod & Service selectors are unaffected** (they only ever matched `name`/`instance`/`component`) — rollouts are safe. Migration: re-add via `global.commonLabels`. Full note in CHANGELOG.

Bumped to **2.0.0** (was incorrectly 1.8.0 — a major signals the output change correctly and also avoids colliding with #68's 1.8.0).

## Verification

- `make lint-chart` — all 16 scenarios pass
- `make unit-test` — 381/381 (19 suites); version-label tests cover: omission when unset, `commonLabels` override, **and** the guarded branch with `appVersion` set (helm-unittest `chart:` override)
- `make kubeconform` — all manifests valid
- Render check: `app.kubernetes.io/version` absent by default