### PR TITLE
fix(externalsecret): allow generator-backed and per-item-store forms (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ---
 
+## [2.4.0] — 2026-08-03
+
+### Added
+
+- `externalSecrets.<name>.target.template` and `.target.immutable`. `template`
+  is passed through verbatim, so ESO's own templating survives untouched and the
+  chart cannot drift from the upstream schema — this is what shapes a generated
+  value into the file a workload expects:
+
+```yaml
+    target:
+      immutable: false
+      template:
+        engineVersion: v2
+        data:
+          .htpasswd: '{{ htpasswd "stage" .password "bcrypt" }}'
+```
+
+  `target.manifest` is deliberately not exposed: it creates a custom resource
+  *instead of* a Secret, so its interaction with the always-emitted `target.name`
+  and `creationPolicy` needs runtime verification against ESO that the current
+  e2e cluster (KEDA only) cannot provide.
+
+### Fixed
+
+- `externalSecrets.<name>.secretstore` is no longer mandatory when every
+  `dataFrom` entry carries its own `sourceRef`. The chart demanded a
+  spec-level store on every ExternalSecret, but `secretStoreRef` is optional in
+  the CRD: an ExternalSecret backed by an ESO *generator* has no store to point
+  at, and one whose entries each carry a per-item `sourceRef.storeRef` already
+  resolves its own. Both forms were unrenderable.
+
+```yaml
+externalSecrets:
+  basicauth:
+    # no secretstore: the generator produces the value
+    dataFrom:
+      - sourceRef:
+          generatorRef:
+            apiVersion: generators.external-secrets.io/v1alpha1
+            kind: Password
+            name: stage-basicauth
+```
+
+  The store stays mandatory for every other form. A `dataFrom` where only some
+  entries carry a `sourceRef` still fails, and so does an empty `dataFrom: []` —
+  it has no entry that could resolve a store, and letting it through would
+  render a store-less, data-less ExternalSecret.
+
+---
+
 ## [2.3.0] — 2026-08-02
 
 ### Added

--- a/charts/global-chart/Chart.yaml
+++ b/charts/global-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.0
+version: 2.4.0
 
 # appVersion is intentionally omitted: this is a generic, reusable chart that
 # deploys arbitrary workloads, so there is no single application version to pin.

--- a/charts/global-chart/README.md
+++ b/charts/global-chart/README.md
@@ -1,6 +1,6 @@
 # global-chart
 
-![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Reusable Helm chart providing common building blocks—Deployments, Services, Ingress, Jobs, and more—for broadly adaptable Kubernetes applications.
 

--- a/charts/global-chart/templates/externalsecret.yaml
+++ b/charts/global-chart/templates/externalsecret.yaml
@@ -1,13 +1,30 @@
 {{- $root := . -}}
 {{- range $name, $secret := .Values.externalSecrets }}
 {{- if $secret }}
-{{- $secretStore := required (printf "externalSecrets.%s.secretstore is mandatory" $name) $secret.secretstore -}}
 {{- $target := default (dict) $secret.target -}}
 {{- $secretName := printf "%s-%s" (include "global-chart.fullname" $root) $name -}}
 {{- $hasData := hasKey $secret "data" -}}
 {{- $hasDataFrom := hasKey $secret "dataFrom" -}}
 {{- if and (or $hasData $hasDataFrom) (or (hasKey $secret "remote") (hasKey $secret "secretkey")) -}}
 {{- fail (printf "externalSecrets.%s: single-key form ('remote'/'secretkey') cannot be combined with 'data' or 'dataFrom'" $name) -}}
+{{- end -}}
+{{/* A dataFrom whose every entry carries its own sourceRef (generatorRef or
+     per-item storeRef) needs no spec-level store: the CRD makes secretStoreRef
+     optional. An empty list is not self-contained — it would render a
+     store-less, data-less ExternalSecret. */}}
+{{- $selfContainedDataFrom := false -}}
+{{- if and $hasDataFrom (not $hasData) (gt (len (default (list) $secret.dataFrom)) 0) -}}
+{{- $selfContainedDataFrom = true -}}
+{{- range $item := $secret.dataFrom -}}
+{{- $sourceRef := default (dict) $item.sourceRef -}}
+{{- if not (or (hasKey $sourceRef "generatorRef") (hasKey $sourceRef "storeRef")) -}}
+{{- $selfContainedDataFrom = false -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- $secretStore := $secret.secretstore -}}
+{{- if not $selfContainedDataFrom -}}
+{{- $secretStore = required (printf "externalSecrets.%s.secretstore is mandatory unless every dataFrom entry carries its own sourceRef (generatorRef or storeRef)" $name) $secret.secretstore -}}
 {{- end -}}
 ---
 apiVersion: external-secrets.io/v1
@@ -43,12 +60,26 @@ spec:
       secretKey: {{ required "secretkey is mandatory" $secret.secretkey | quote }}
   {{- end }}
   refreshInterval: {{ ternary $secret.refreshInterval "1h" (hasKey $secret "refreshInterval") | quote }}
+  {{- /* Emitted whenever a store is required — so an incomplete secretstore
+         still fails on the store-backed path — and also when a self-contained
+         dataFrom supplies one anyway: ESO lets a per-item sourceRef override a
+         spec-level store. A self-contained dataFrom with an empty secretstore
+         is the one case that renders neither: nothing to emit, nothing needed. */}}
+  {{- if or (not $selfContainedDataFrom) $secretStore }}
   secretStoreRef:
     kind: {{ required (printf "externalSecrets.%s.secretstore.kind is mandatory" $name) $secretStore.kind | quote }}
     name: {{ required (printf "externalSecrets.%s.secretstore.name is mandatory" $name) $secretStore.name | quote }}
+  {{- end }}
   target:
     creationPolicy: {{ ternary $target.creationPolicy "Owner" (hasKey $target "creationPolicy") | quote }}
     deletionPolicy: {{ ternary $target.deletionPolicy "Retain" (hasKey $target "deletionPolicy") | quote }}
     name: {{ ternary $target.name $secretName (hasKey $target "name") | quote }}
+    {{- if hasKey $target "immutable" }}
+    immutable: {{ $target.immutable }}
+    {{- end }}
+    {{- with $target.template }}
+    template:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{ end }}
 {{- end }}

--- a/charts/global-chart/tests/externalsecret_test.yaml
+++ b/charts/global-chart/tests/externalsecret_test.yaml
@@ -325,3 +325,167 @@ tests:
           value: "shared/app"
       - notExists:
           path: spec.data
+
+  # ====== generator-backed / per-item store (no spec-level secretstore) ======
+
+  - it: should render a generator-backed dataFrom without a secretStoreRef
+    set:
+      externalSecrets:
+        basicauth:
+          dataFrom:
+            - sourceRef:
+                generatorRef:
+                  apiVersion: generators.external-secrets.io/v1alpha1
+                  kind: Password
+                  name: stage-basicauth
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: spec.dataFrom[0].sourceRef.generatorRef.kind
+          value: "Password"
+      - equal:
+          path: spec.dataFrom[0].sourceRef.generatorRef.name
+          value: "stage-basicauth"
+      - notExists:
+          path: spec.secretStoreRef
+
+  - it: should render a per-item storeRef without a secretStoreRef
+    set:
+      externalSecrets:
+        app:
+          dataFrom:
+            - sourceRef:
+                storeRef:
+                  kind: ClusterSecretStore
+                  name: my-store
+              extract:
+                key: shared/app
+    asserts:
+      - equal:
+          path: spec.dataFrom[0].sourceRef.storeRef.name
+          value: "my-store"
+      - notExists:
+          path: spec.secretStoreRef
+
+  - it: should render target.template verbatim
+    set:
+      externalSecrets:
+        basicauth:
+          dataFrom:
+            - sourceRef:
+                generatorRef:
+                  apiVersion: generators.external-secrets.io/v1alpha1
+                  kind: Password
+                  name: stage-basicauth
+          target:
+            template:
+              engineVersion: v2
+              data:
+                .htpasswd: '{{ htpasswd "stage" .password "bcrypt" }}'
+    asserts:
+      - equal:
+          path: spec.target.template.engineVersion
+          value: "v2"
+      - equal:
+          path: spec.target.template.data[".htpasswd"]
+          value: '{{ htpasswd "stage" .password "bcrypt" }}'
+
+  - it: should render target.immutable false without turning it into true
+    set:
+      externalSecrets:
+        app:
+          secretstore:
+            kind: ClusterSecretStore
+            name: my-store
+          secretkey: password
+          remote:
+            key: /prod/db/password
+          target:
+            immutable: false
+    asserts:
+      - equal:
+          path: spec.target.immutable
+          value: false
+
+  - it: should omit target.immutable when unset
+    set:
+      externalSecrets:
+        app:
+          secretstore:
+            kind: ClusterSecretStore
+            name: my-store
+          secretkey: password
+          remote:
+            key: /prod/db/password
+    asserts:
+      - notExists:
+          path: spec.target.immutable
+
+  - it: should still demand secretstore.kind when secretstore is an empty map
+    set:
+      externalSecrets:
+        app:
+          secretkey: password
+          remote:
+            key: /prod/db/password
+          secretstore: {}
+    asserts:
+      - failedTemplate:
+          errorPattern: "externalSecrets.app.secretstore.kind is mandatory"
+
+  - it: should keep a spec-level secretstore alongside a self-contained dataFrom
+    set:
+      externalSecrets:
+        app:
+          secretstore:
+            kind: ClusterSecretStore
+            name: my-store
+          dataFrom:
+            - sourceRef:
+                generatorRef:
+                  apiVersion: generators.external-secrets.io/v1alpha1
+                  kind: Password
+                  name: stage-basicauth
+    asserts:
+      - equal:
+          path: spec.secretStoreRef.name
+          value: "my-store"
+
+  - it: should fail when only some dataFrom entries carry a sourceRef
+    set:
+      externalSecrets:
+        app:
+          dataFrom:
+            - sourceRef:
+                generatorRef:
+                  apiVersion: generators.external-secrets.io/v1alpha1
+                  kind: Password
+                  name: stage-basicauth
+            - find:
+                name:
+                  regexp: "^APP_.*"
+    asserts:
+      - failedTemplate:
+          errorPattern: "externalSecrets.app.secretstore is mandatory"
+
+  - it: should fail on an empty dataFrom list without a secretstore
+    set:
+      externalSecrets:
+        app:
+          dataFrom: []
+    asserts:
+      - failedTemplate:
+          errorPattern: "externalSecrets.app.secretstore is mandatory"
+
+  - it: should still demand a secretstore for a store-backed dataFrom
+    set:
+      externalSecrets:
+        app:
+          dataFrom:
+            - find:
+                name:
+                  regexp: "^APP_.*"
+    asserts:
+      - failedTemplate:
+          errorPattern: "externalSecrets.app.secretstore is mandatory"

--- a/charts/global-chart/values.schema.json
+++ b/charts/global-chart/values.schema.json
@@ -753,7 +753,9 @@
           "properties": {
             "creationPolicy": { "type": "string" },
             "deletionPolicy": { "type": "string" },
-            "name": { "type": "string" }
+            "name": { "type": "string" },
+            "immutable": { "type": "boolean" },
+            "template": { "type": "object" }
           },
           "additionalProperties": false
         }

--- a/charts/global-chart/values.yaml
+++ b/charts/global-chart/values.yaml
@@ -464,6 +464,24 @@ externalSecrets: {}
   #   secretstore: { kind: ClusterSecretStore, name: my-store }
   #   dataFrom:
   #     - find: { name: { regexp: "^APP_.*" } }
+  #
+  # generator form: every dataFrom entry carries its own sourceRef
+  # (generatorRef, or a per-item storeRef), so secretstore is not required.
+  # target.template shapes the resulting Secret; it is passed through verbatim,
+  # so ESO's own templating functions survive untouched:
+  # basicauth:
+  #   dataFrom:
+  #     - sourceRef:
+  #         generatorRef:
+  #           apiVersion: generators.external-secrets.io/v1alpha1
+  #           kind: Password
+  #           name: stage-basicauth
+  #   target:
+  #     immutable: false
+  #     template:
+  #       engineVersion: v2
+  #       data:
+  #         .htpasswd: '{{ htpasswd "stage" .password "bcrypt" }}'
 
 # -- KEDA TriggerAuthentication definitions, shared by the triggers of any
 # deployment. Rendered as `{release}-{chart}-{key}`; reference them from a

--- a/tests/bad-values/externalsecret-no-store-no-generator.yaml
+++ b/tests/bad-values/externalsecret-no-store-no-generator.yaml
@@ -1,0 +1,9 @@
+# dataFrom entry with a bare selector and no sourceRef: the spec-level
+# secretstore stays mandatory, because nothing in the entry can resolve a store.
+# Rejected by the template, not the schema (chart pattern 10).
+externalSecrets:
+  app:
+    dataFrom:
+      - find:
+          name:
+            regexp: "^APP_.*"

--- a/tests/externalsecret-only.yaml
+++ b/tests/externalsecret-only.yaml
@@ -33,6 +33,21 @@ externalSecrets:
       - find:
           name:
             regexp: "^APP_.*"
+  # generator form: the value is produced by an ESO generator, so there is no
+  # store to point at and secretstore is omitted
+  basicauth:
+    dataFrom:
+      - sourceRef:
+          generatorRef:
+            apiVersion: generators.external-secrets.io/v1alpha1
+            kind: Password
+            name: stage-basicauth
+    target:
+      immutable: false
+      template:
+        engineVersion: v2
+        data:
+          .htpasswd: '{{ htpasswd "stage" .password "bcrypt" }}'
   # data + dataFrom together (both rendered, ESO supports both)
   app-mixed:
     secretstore:


### PR DESCRIPTION
Closes #78.

The chart demanded a spec-level `secretstore` on every ExternalSecret, but `secretStoreRef` is optional in the CRD. That made two valid ESO shapes unrenderable: one backed by a generator, which has no store to point at, and one whose `dataFrom` entries each carry a per-item `sourceRef.storeRef` and already resolve their own.

The issue only names `generatorRef`, but the same line rejected `sourceRef.storeRef` — fixing one and leaving the other would keep a guard we already know is wrong.

## Changes

- **`secretstore` is required only when the render actually needs one.** A `dataFrom` where *every* entry carries a `sourceRef` (`generatorRef` or `storeRef`) renders without `spec.secretStoreRef`. Everything else still fails as before, and the error keeps the old message prefix verbatim, so no existing test needed rewriting.
- **An empty `dataFrom: []` is deliberately not self-contained**: it has no entry that could resolve a store, and letting it through would render a store-less, data-less ExternalSecret.
- **`secretStoreRef` is still emitted when a self-contained `dataFrom` supplies a store anyway** — ESO lets a per-item `sourceRef` override a spec-level one — and both inner `required` calls stay, so an incomplete `secretstore` is still rejected on the store-backed path.
- **`target.template` and `target.immutable` accepted and rendered.** `template` passes through `toYaml` verbatim, as `dataFrom` already does, so the chart cannot drift from the upstream schema and ESO's own templating functions survive untouched. `immutable` is guarded with `hasKey`, never `default`, and a test locks `false` against a future regression.

```yaml
externalSecrets:
  basicauth:
    # no secretstore: the generator produces the value
    dataFrom:
      - sourceRef:
          generatorRef:
            apiVersion: generators.external-secrets.io/v1alpha1
            kind: Password
            name: stage-basicauth
    target:
      template:
        engineVersion: v2
        data:
          .htpasswd: '{{ htpasswd "stage" .password "bcrypt" }}'
```

## Out of scope

`target.manifest` is deliberately left out: it creates a custom resource *instead of* a Secret, so its interaction with the always-emitted `target.name` and `creationPolicy` needs runtime verification against ESO that the e2e cluster (KEDA only) cannot provide.

`make e2e` is not extended for the same reason — it installs KEDA, not ESO, and this change has no hook/ordering/lifecycle dimension.

## Test plan

`make all` green: lint-chart, 456 unit tests, bad-values, kubeconform (203 resources), kube-linter, generate-docs.

- 10 new unit tests: generator-only, per-item `storeRef`, `target.template` verbatim, `immutable: false`, `immutable` omitted when unset, spec-level store kept alongside a self-contained `dataFrom`, empty `secretstore: {}` still failing, mixed `dataFrom`, `dataFrom: []`, store-backed `dataFrom` without a store.
- `tests/bad-values/externalsecret-no-store-no-generator.yaml` for the rejection path.
- The store-less form added to the `tests/externalsecret-only.yaml` lint scenario, so `make kubeconform` validates it against the real ESO CRD schema — the strongest available check that omitting `secretStoreRef` is legal.

Chart version 2.3.0 → 2.4.0.
