### PR TITLE
feat(externalsecret): remoteRef property and version (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ---
 
-## [Unreleased]
+## [2.5.0] — 2026-08-04
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,13 @@ externalSecrets:
 
   Unlike the three strategy fields the chart applies no default to either — ESO
   defaults them at the CRD level — so both are omitted from the rendered
-  `remoteRef` when unset. `dataFrom[].extract` already accepted both, since it is
-  rendered verbatim. Additive and backwards compatible.
+  `remoteRef` when the key is absent. Presence is decided by `hasKey`, not
+  truthiness: an explicit `property: ""` is the user's input and is passed
+  through rather than silently dropped. `version` accepts a string or a number
+  and is quoted on render, so the natural `version: 3` works as well as
+  `version: "3"` — the same leniency `image.tag` already has.
+  `dataFrom[].extract` already accepted both, since it is rendered verbatim.
+  Additive and backwards compatible.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- `property` and `version` on `externalSecrets.<name>.remote` and
+  `externalSecrets.<name>.data[].remote`. `property` is a gjson path that selects
+  a single key out of a remote secret whose payload is a JSON bundle — previously
+  the only way to get one key out of a bundle was to pull the whole thing and
+  reshape it with `target.template` + `fromJson`. `version` pins a version of the
+  remote secret instead of the provider default (`latest` on Google Secret
+  Manager):
+
+```yaml
+externalSecrets:
+  app:
+    secretstore: { kind: ClusterSecretStore, name: gcp-store }
+    data:
+      - secretkey: DB_PASSWORD
+        remote: { key: apps/prod/bundle, property: db_password }
+      - secretkey: API_TOKEN
+        remote: { key: apps/prod/bundle, property: api_token, version: "3" }
+```
+
+  Unlike the three strategy fields the chart applies no default to either — ESO
+  defaults them at the CRD level — so both are omitted from the rendered
+  `remoteRef` when unset. `dataFrom[].extract` already accepted both, since it is
+  rendered verbatim. Additive and backwards compatible.
+
+---
+
 ## [2.4.0] — 2026-08-03
 
 ### Added

--- a/charts/global-chart/Chart.yaml
+++ b/charts/global-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.0
+version: 2.5.0
 
 # appVersion is intentionally omitted: this is a generic, reusable chart that
 # deploys arbitrary workloads, so there is no single application version to pin.

--- a/charts/global-chart/README.md
+++ b/charts/global-chart/README.md
@@ -1,6 +1,6 @@
 # global-chart
 
-![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.5.0](https://img.shields.io/badge/Version-2.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Reusable Helm chart providing common building blocks—Deployments, Services, Ingress, Jobs, and more—for broadly adaptable Kubernetes applications.
 

--- a/charts/global-chart/README.md
+++ b/charts/global-chart/README.md
@@ -51,7 +51,7 @@ Kubernetes: `>=1.19.0-0`
 | httpRoute.rules | list | `[]` | Routing rules. Each rule may declare matches, filters, backendRefs, timeouts. backendRefs accept either `deployment: <name>` (resolves to the chart-managed Service) or `service: { name, port }` for an external Service. |
 | cronJobs | object | `{}` | CronJobs configuration (map of named cronJobs). Can also be defined inside deployments to inherit image, configMap, secret, SA. |
 | hooks | object | `{}` | Hook jobs for chart lifecycle (install/upgrade). Can also be defined inside deployments to inherit image, configMap, secret, SA. |
-| externalSecrets | object | `{}` | ExternalSecrets definitions for secret management |
+| externalSecrets | object | `{}` | ExternalSecrets definitions for secret management. Each entry renders one ExternalSecret. The `remote` map (single-key form) and each `data[].remote` accept `key`, `property` (a gjson path selecting one key out of a JSON payload), `version` (string or number, quoted on render), `conversionStrategy`, `decodingStrategy` and `metadataPolicy`. `dataFrom` is rendered verbatim. |
 | kedaTriggerAuthentications | object | `{}` | KEDA TriggerAuthentication definitions, shared by the triggers of any deployment. Rendered as `{release}-{chart}-{key}`; reference them from a trigger by their key here and the chart resolves the full name. |
 | defaults | object | `{"resources":{"requests":{"cpu":"100m","memory":"128Mi"}}}` | Default resource settings for CronJobs and Hooks when not specified per-job |
 | rbacs | object | `{"roles":[]}` | RBAC configuration: create multiple service accounts, roles and rolebindings |

--- a/charts/global-chart/templates/_render-helpers.tpl
+++ b/charts/global-chart/templates/_render-helpers.tpl
@@ -192,12 +192,13 @@ Output: JSON string of the form {"name":"<svc>","port":<int>}
 {{- end }}
 
 {{/*
-Render an ExternalSecret remoteRef block (the four strategy/key fields), shared
-by both the data-list and single-key branches of externalsecret.yaml so their
-defaults can never drift.
+Render an ExternalSecret remoteRef block, shared by both the data-list and
+single-key branches of externalsecret.yaml so their defaults can never drift.
+`property` and `version` carry no chart-side default — ESO defaults them at the
+CRD level — so they are emitted only when set.
 Usage: {{- include "global-chart.renderExternalSecretRemoteRef" (dict "remote" $remote "keyError" (printf "externalSecrets.%s.remote.key is mandatory" $name)) | nindent 8 }}
 Inputs (dict):
-  - remote    (required) — the remote map (key + optional conversion/decoding/metadata strategies)
+  - remote    (required) — the remote map (key + optional conversion/decoding/metadata strategies, property, version)
   - keyError  (required) — fail message when remote.key is missing (caller supplies the exact path)
 */}}
 {{- define "global-chart.renderExternalSecretRemoteRef" -}}
@@ -206,4 +207,10 @@ conversionStrategy: {{ ternary $remote.conversionStrategy "Default" (hasKey $rem
 decodingStrategy: {{ ternary $remote.decodingStrategy "None" (hasKey $remote "decodingStrategy") | quote }}
 key: {{ required .keyError $remote.key | quote }}
 metadataPolicy: {{ ternary $remote.metadataPolicy "None" (hasKey $remote "metadataPolicy") | quote }}
+{{- with $remote.property }}
+property: {{ . | quote }}
+{{- end }}
+{{- with $remote.version }}
+version: {{ . | quote }}
+{{- end }}
 {{- end }}

--- a/charts/global-chart/templates/_render-helpers.tpl
+++ b/charts/global-chart/templates/_render-helpers.tpl
@@ -195,7 +195,10 @@ Output: JSON string of the form {"name":"<svc>","port":<int>}
 Render an ExternalSecret remoteRef block, shared by both the data-list and
 single-key branches of externalsecret.yaml so their defaults can never drift.
 `property` and `version` carry no chart-side default — ESO defaults them at the
-CRD level — so they are emitted only when set.
+CRD level — so they are emitted only when the key is present, keyed on `hasKey`
+rather than truthiness: an explicit empty string is the user's input and is
+passed through, not silently dropped. `version` goes through `quote` because the
+schema accepts a number for it (`version: 3`) while the CRD wants a string.
 Usage: {{- include "global-chart.renderExternalSecretRemoteRef" (dict "remote" $remote "keyError" (printf "externalSecrets.%s.remote.key is mandatory" $name)) | nindent 8 }}
 Inputs (dict):
   - remote    (required) — the remote map (key + optional conversion/decoding/metadata strategies, property, version)
@@ -207,10 +210,10 @@ conversionStrategy: {{ ternary $remote.conversionStrategy "Default" (hasKey $rem
 decodingStrategy: {{ ternary $remote.decodingStrategy "None" (hasKey $remote "decodingStrategy") | quote }}
 key: {{ required .keyError $remote.key | quote }}
 metadataPolicy: {{ ternary $remote.metadataPolicy "None" (hasKey $remote "metadataPolicy") | quote }}
-{{- with $remote.property }}
-property: {{ . | quote }}
+{{- if hasKey $remote "property" }}
+property: {{ $remote.property | quote }}
 {{- end }}
-{{- with $remote.version }}
-version: {{ . | quote }}
+{{- if hasKey $remote "version" }}
+version: {{ $remote.version | quote }}
 {{- end }}
 {{- end }}

--- a/charts/global-chart/tests/externalsecret_test.yaml
+++ b/charts/global-chart/tests/externalsecret_test.yaml
@@ -556,6 +556,38 @@ tests:
       - notExists:
           path: spec.data[1].remoteRef.version
 
+  - it: should quote a numeric version instead of rejecting it
+    set:
+      externalSecrets:
+        app:
+          secretstore:
+            kind: ClusterSecretStore
+            name: gcp-store
+          secretkey: DB_PASSWORD
+          remote:
+            key: apps/prod/bundle
+            version: 3
+    asserts:
+      - equal:
+          path: spec.data[0].remoteRef.version
+          value: "3"
+
+  - it: should keep an explicit empty property instead of dropping it
+    set:
+      externalSecrets:
+        app:
+          secretstore:
+            kind: ClusterSecretStore
+            name: gcp-store
+          secretkey: DB_PASSWORD
+          remote:
+            key: apps/prod/bundle
+            property: ""
+    asserts:
+      - equal:
+          path: spec.data[0].remoteRef.property
+          value: ""
+
   - it: should omit property and version when unset
     set:
       externalSecrets:

--- a/charts/global-chart/tests/externalsecret_test.yaml
+++ b/charts/global-chart/tests/externalsecret_test.yaml
@@ -489,3 +489,85 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "externalSecrets.app.secretstore is mandatory"
+
+  - it: should render remote.property alone
+    set:
+      externalSecrets:
+        app:
+          secretstore:
+            kind: ClusterSecretStore
+            name: gcp-store
+          secretkey: DB_PASSWORD
+          remote:
+            key: apps/prod/bundle
+            property: db_password
+    asserts:
+      - equal:
+          path: spec.data[0].remoteRef.property
+          value: "db_password"
+      - notExists:
+          path: spec.data[0].remoteRef.version
+
+  - it: should render remote.version alone
+    set:
+      externalSecrets:
+        app:
+          secretstore:
+            kind: ClusterSecretStore
+            name: gcp-store
+          secretkey: DB_PASSWORD
+          remote:
+            key: apps/prod/bundle
+            version: "3"
+    asserts:
+      - equal:
+          path: spec.data[0].remoteRef.version
+          value: "3"
+      - notExists:
+          path: spec.data[0].remoteRef.property
+
+  - it: should render both property and version on a data list item
+    set:
+      externalSecrets:
+        app:
+          secretstore:
+            kind: ClusterSecretStore
+            name: gcp-store
+          data:
+            - secretkey: DB_PASSWORD
+              remote:
+                key: apps/prod/bundle
+                property: db_password
+                version: "3"
+            - secretkey: API_TOKEN
+              remote:
+                key: apps/prod/bundle
+                property: api_token
+    asserts:
+      - equal:
+          path: spec.data[0].remoteRef.property
+          value: "db_password"
+      - equal:
+          path: spec.data[0].remoteRef.version
+          value: "3"
+      - equal:
+          path: spec.data[1].remoteRef.property
+          value: "api_token"
+      - notExists:
+          path: spec.data[1].remoteRef.version
+
+  - it: should omit property and version when unset
+    set:
+      externalSecrets:
+        app:
+          secretstore:
+            kind: ClusterSecretStore
+            name: gcp-store
+          secretkey: DB_PASSWORD
+          remote:
+            key: apps/prod/db-password
+    asserts:
+      - notExists:
+          path: spec.data[0].remoteRef.property
+      - notExists:
+          path: spec.data[0].remoteRef.version

--- a/charts/global-chart/values.schema.json
+++ b/charts/global-chart/values.schema.json
@@ -704,7 +704,7 @@
         "decodingStrategy": { "type": "string" },
         "metadataPolicy": { "type": "string" },
         "property": { "type": "string" },
-        "version": { "type": "string" }
+        "version": { "type": ["string", "number"] }
       },
       "additionalProperties": false
     },

--- a/charts/global-chart/values.schema.json
+++ b/charts/global-chart/values.schema.json
@@ -702,7 +702,9 @@
         "key": { "type": "string" },
         "conversionStrategy": { "type": "string" },
         "decodingStrategy": { "type": "string" },
-        "metadataPolicy": { "type": "string" }
+        "metadataPolicy": { "type": "string" },
+        "property": { "type": "string" },
+        "version": { "type": "string" }
       },
       "additionalProperties": false
     },

--- a/charts/global-chart/values.yaml
+++ b/charts/global-chart/values.yaml
@@ -459,6 +459,16 @@ externalSecrets: {}
   #     - { secretkey: DB_PASSWORD, remote: { key: MY_DB_PASSWORD } }
   #     - { secretkey: API_TOKEN,  remote: { key: MY_API_TOKEN } }
   #
+  # remote.property picks a single key out of a remote secret whose payload is a
+  # JSON bundle (it is a gjson path); remote.version pins a specific version of
+  # the remote secret instead of the provider default. Both are omitted from the
+  # rendered remoteRef when unset:
+  # app-bundle:
+  #   secretstore: { kind: ClusterSecretStore, name: gcp-store }
+  #   data:
+  #     - { secretkey: DB_PASSWORD, remote: { key: apps/prod/bundle, property: db_password } }
+  #     - { secretkey: API_TOKEN,   remote: { key: apps/prod/bundle, property: api_token, version: "3" } }
+  #
   # dataFrom form (extract / find), rendered verbatim:
   # app-bulk:
   #   secretstore: { kind: ClusterSecretStore, name: my-store }

--- a/charts/global-chart/values.yaml
+++ b/charts/global-chart/values.yaml
@@ -442,7 +442,11 @@ hooks: {}
   #     weight: "10"
   #     deletePolicy: before-hook-creation
 
-# -- ExternalSecrets definitions for secret management
+# -- ExternalSecrets definitions for secret management. Each entry renders one
+# ExternalSecret. The `remote` map (single-key form) and each `data[].remote`
+# accept `key`, `property` (a gjson path selecting one key out of a JSON
+# payload), `version` (string or number, quoted on render), `conversionStrategy`,
+# `decodingStrategy` and `metadataPolicy`. `dataFrom` is rendered verbatim.
 externalSecrets: {}
   # Single-key form (one remote key -> one Secret key):
   # single:

--- a/tests/bad-values/externalsecret-remote-unknown-key.yaml
+++ b/tests/bad-values/externalsecret-remote-unknown-key.yaml
@@ -1,0 +1,13 @@
+# A remote map with an unknown key (typo of "property") must be rejected by the
+# schema before it reaches external-secrets at apply time. $defs.externalSecretRemote
+# keeps additionalProperties: false precisely so a silently-ignored typo cannot
+# leave the ExternalSecret pointing at the whole payload instead of one key.
+externalSecrets:
+  app:
+    secretstore:
+      kind: ClusterSecretStore
+      name: my-store
+    secretkey: DB_PASSWORD
+    remote:
+      key: apps/prod/bundle
+      propery: db_password

--- a/tests/externalsecret-only.yaml
+++ b/tests/externalsecret-only.yaml
@@ -24,6 +24,21 @@ externalSecrets:
       - secretkey: API_TOKEN
         remote:
           key: MY_API_TOKEN
+  # property/version: one key out of a JSON bundle, at a pinned version
+  app-bundle:
+    secretstore:
+      kind: ClusterSecretStore
+      name: default-store
+    data:
+      - secretkey: DB_PASSWORD
+        remote:
+          key: apps/prod/bundle
+          property: db_password
+      - secretkey: API_TOKEN
+        remote:
+          key: apps/prod/bundle
+          property: api_token
+          version: "3"
   # dataFrom form: extract / find
   app-bulk:
     secretstore:


### PR DESCRIPTION
`externalSecrets.<name>.remote` and `.data[].remote` could not express
`remoteRef.property` or `remoteRef.version`, both plain fields of the upstream
`remoteRef` in `external-secrets.io/v1`. That made the chart strictly narrower
than the CRD: with a secret whose payload is a JSON bundle there was no way to
project a single key into a Secret key, short of pulling the whole bundle and
reshaping it with `target.template` + `fromJson` — which routes the secret
payload through the chart's templating for no reason.

Two independent places blocked it, both fixed:

- `$defs.externalSecretRemote` in the schema has `additionalProperties: false`,
  so `property` was rejected at install/lint time. `property` is `type: string`;
  `version` accepts `["string", "number"]` and is quoted on render, so the
  natural `version: 3` works as well as `version: "3"` — the same leniency
  `image.tag` already has, and the CRD gets the string it wants either way.
- `renderExternalSecretRemoteRef` rendered only `key` and the three strategy
  fields, so the value would have been dropped anyway.

Unlike the strategy fields, neither gets a chart-side default — ESO defaults
them at the CRD level — so both are absent from the rendered `remoteRef` when
the key is absent, rather than pinned to a value the chart invented. Presence is
decided by `hasKey`, not truthiness, matching the three strategy fields on the
adjacent lines of the same helper: an explicit `property: ""` is the user's
input and is passed through rather than silently dropped.

`dataFrom[].extract` already accepted both, since the schema keeps `extract` as
a free object and the template renders `dataFrom` verbatim. The gap was limited
to `remote` / `data[].remote`.

Covered by unit tests for each field alone, both together on a `data` list, the
absence of both, a numeric `version` rendering as `"3"`, and `property: ""`
surviving as an empty string. `tests/bad-values/externalsecret-remote-unknown-key.yaml`
pins `additionalProperties: false` against a `propery:` typo, mirroring the
existing `externalsecret-datafrom-unknown-key.yaml` — a misspelled `property`
otherwise fails open, leaving the ExternalSecret pointed at the whole payload.
The lint scenario in `tests/externalsecret-only.yaml` is what exercises the
schema against the new fields.

Also here, outside the original issue's scope: helm-docs rendered
`externalSecrets` with a one-line description documenting none of its
sub-fields, because the block is a free-form map whose examples live in
comments. Its `# --` comment now names the fields `remote`/`data[].remote`
accept, so the generated README table carries them.

Released as 2.5.0 — minor, the fields are additive.

Closes #80
